### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-documentdb.gemspec
+++ b/fluent-plugin-documentdb.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|gem|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_dependency "rest-client"
   gem.add_development_dependency "bundler", "~> 1.11"
   gem.add_development_dependency "rake", "~> 10.0"

--- a/lib/fluent/plugin/out_documentdb.rb
+++ b/lib/fluent/plugin/out_documentdb.rb
@@ -18,10 +18,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    def initialize
-      super
-    end
-
     config_param :docdb_endpoint, :string
     config_param :docdb_account_key, :string, :secret => true
     config_param :docdb_database, :string

--- a/lib/fluent/plugin/out_documentdb.rb
+++ b/lib/fluent/plugin/out_documentdb.rb
@@ -42,21 +42,21 @@ module Fluent::Plugin
     def configure(conf)
       compat_parameters_convert(conf, :buffer)
       super
-      raise ConfigError, 'no docdb_endpoint' if @docdb_endpoint.empty?
-      raise ConfigError, 'no docdb_account_key' if @docdb_account_key.empty?
-      raise ConfigError, 'no docdb_database' if @docdb_database.empty?
-      raise ConfigError, 'no docdb_collection' if @docdb_collection.empty?
+      raise Fluent::ConfigError, 'no docdb_endpoint' if @docdb_endpoint.empty?
+      raise Fluent::ConfigError, 'no docdb_account_key' if @docdb_account_key.empty?
+      raise Fluent::ConfigError, 'no docdb_database' if @docdb_database.empty?
+      raise Fluent::ConfigError, 'no docdb_collection' if @docdb_collection.empty?
       if @add_time_field and @time_field_name.empty?
-        raise ConfigError, 'time_field_name must be set if add_time_field is true'
+        raise Fluent::ConfigError, 'time_field_name must be set if add_time_field is true'
       end
       if @add_tag_field and @tag_field_name.empty?
-        raise ConfigError, 'tag_field_name must be set if add_tag_field is true'
+        raise Fluent::ConfigError, 'tag_field_name must be set if add_tag_field is true'
       end
       if @partitioned_collection
-        raise ConfigError, 'partition_key must be set in partitioned collection mode' if @partition_key.empty?
+        raise Fluent::ConfigError, 'partition_key must be set in partitioned collection mode' if @partition_key.empty?
         if (@auto_create_collection &&
               @offer_throughput < AzureDocumentDB::PARTITIONED_COLL_MIN_THROUGHPUT)
-          raise ConfigError, sprintf("offer_throughput must be more than and equals to %s",
+          raise Fluent::ConfigError, sprintf("offer_throughput must be more than and equals to %s",
                                  AzureDocumentDB::PARTITIONED_COLL_MIN_THROUGHPUT)
         end
       end

--- a/lib/fluent/plugin/out_documentdb.rb
+++ b/lib/fluent/plugin/out_documentdb.rb
@@ -11,10 +11,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    unless method_defined?(:log)
-      define_method('log') { $log }
-    end
-
     def initialize
       super
       require 'msgpack'

--- a/lib/fluent/plugin/out_documentdb.rb
+++ b/lib/fluent/plugin/out_documentdb.rb
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 require 'fluent/plugin/output'
-module Fluent::Plugin
+require 'msgpack'
+require 'time'
+require 'securerandom'
+require 'fluent/plugin/documentdb/client'
+require 'fluent/plugin/documentdb/partitioned_coll_client'
+require 'fluent/plugin/documentdb/header'
+require 'fluent/plugin/documentdb/resource'
+require 'fluent/plugin/documentdb/constants'
 
-  require 'fluent/plugin/documentdb/constants'
+module Fluent::Plugin
 
   class DocumentdbOutput < Output
     Fluent::Plugin.register_output('documentdb', self)
@@ -13,13 +20,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'msgpack'
-      require 'time'
-      require 'securerandom'
-      require 'fluent/plugin/documentdb/client'
-      require 'fluent/plugin/documentdb/partitioned_coll_client'
-      require 'fluent/plugin/documentdb/header'
-      require 'fluent/plugin/documentdb/resource'
     end
 
     config_param :docdb_endpoint, :string

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_documentdb'
 
 class Test::Unit::TestCase


### PR DESCRIPTION
I've tried to use v0.14 Output plugin API in this plugin.
I've tested with the following configuration(without sensitive information):

```aconf
<source>
  @type forward
</source>
<match documentdb.*>
   @type documentdb
   docdb_endpoint  https://<MY ENDPOINT>.documents.azure.com:443/
   docdb_account_key <MY ACCOUNT KEY>
   docdb_database mydb
   docdb_collection my-partitioned-collection
   auto_create_database true
   auto_create_collection true
   partitioned_collection true
   partition_key host
   offer_throughput 10100
   localtime true
   time_format %Y%m%d-%H:%M:%S
   add_time_field true
   time_field_name time
   add_tag_field true
   tag_field_name tag
</match>
```

And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.